### PR TITLE
chore: remove unused React imports

### DIFF
--- a/wv-wild-web/src/components/adventures/filters/DifficultyFilter.tsx
+++ b/wv-wild-web/src/components/adventures/filters/DifficultyFilter.tsx
@@ -4,7 +4,6 @@
  * WVWO Aesthetic: 44×44px touch targets, rounded-sm, brand colors
  */
 
-import React from 'react';
 import { useFilters } from '@/lib/adventures/FilterContext';
 import { FILTER_CONFIG } from '@/lib/adventures/filters.config';
 

--- a/wv-wild-web/src/components/adventures/filters/ElevationSlider.tsx
+++ b/wv-wild-web/src/components/adventures/filters/ElevationSlider.tsx
@@ -5,7 +5,6 @@
  * WVWO Aesthetic: 44×44px thumbs, rounded-sm, sign-green accent
  */
 
-import React from 'react';
 import ReactSlider from 'react-slider';
 import { useFilters } from '@/lib/adventures/FilterContext';
 import { FILTER_CONFIG } from '@/lib/adventures/filters.config';

--- a/wv-wild-web/src/components/adventures/filters/FilterBar.tsx
+++ b/wv-wild-web/src/components/adventures/filters/FilterBar.tsx
@@ -4,7 +4,6 @@
  * WVWO Aesthetic: Sticky sidebar, 1/4 width, rounded-sm, brand colors
  */
 
-import React from 'react';
 import { useFilters } from '@/lib/adventures/FilterContext';
 import { hasActiveFilters } from '@/lib/adventures/filter-utils';
 import { SeasonFilter } from './SeasonFilter';

--- a/wv-wild-web/src/components/adventures/filters/GearFilter.tsx
+++ b/wv-wild-web/src/components/adventures/filters/GearFilter.tsx
@@ -5,7 +5,7 @@
  * WVWO Aesthetic: 44×44px touch targets, rounded-sm, brand colors
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useFilters } from '@/lib/adventures/FilterContext';
 import { FILTER_CONFIG } from '@/lib/adventures/filters.config';
 

--- a/wv-wild-web/src/components/adventures/filters/SeasonFilter.tsx
+++ b/wv-wild-web/src/components/adventures/filters/SeasonFilter.tsx
@@ -4,7 +4,6 @@
  * WVWO Aesthetic: 44×44px touch targets, rounded-sm, brand colors
  */
 
-import React from 'react';
 import { useFilters } from '@/lib/adventures/FilterContext';
 import { FILTER_CONFIG } from '@/lib/adventures/filters.config';
 

--- a/wv-wild-web/src/components/adventures/filters/SuitabilityFilter.tsx
+++ b/wv-wild-web/src/components/adventures/filters/SuitabilityFilter.tsx
@@ -5,7 +5,6 @@
  * WVWO Aesthetic: 44×44px touch targets, rounded-sm, brand colors
  */
 
-import React from 'react';
 import { useFilters } from '@/lib/adventures/FilterContext';
 import { FILTER_CONFIG } from '@/lib/adventures/filters.config';
 


### PR DESCRIPTION
## Summary

Cleanup PR to remove unused React imports from filter components.

React 17+ JSX transform doesn't require importing React for JSX syntax.

### Changes

Removed `import React from 'react'` from:
- DifficultyFilter.tsx
- SeasonFilter.tsx
- GearFilter.tsx (kept `useState`)
- SuitabilityFilter.tsx
- FilterBar.tsx
- ElevationSlider.tsx

### Result

- TypeScript warnings reduced from 7+ to 1
- No functional changes
- Build still produces 57 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)